### PR TITLE
Fix section scrape crashing on sections with no waitlist

### DIFF
--- a/sections.py
+++ b/sections.py
@@ -66,6 +66,33 @@ def parse_meeting(div: BeautifulSoup):
 
     return f'{days}-{start}-{end}-{location}'
 
+def parse_waitlist_and_holdfile(div: BeautifulSoup):
+    '''
+    Returns `(waitlist, holdfile)` for a section.
+
+    Testudo renders both counts as `waitlist-count` spans inside a single
+    `waitlist` wrapper, telling them apart only by the `seats-info-label` that
+    precedes each one. A section that doesn't run a waitlist still gets the
+    wrapper, but it holds just the help link and no counts at all - roughly 9%
+    of sections in a term - so reading the spans by position raises
+    `IndexError` on those and kills the whole scrape.
+    '''
+    counts = {}
+    spans = div.find_all('span', class_='waitlist-count')
+    for index, span in enumerate(spans):
+        label = span.find_previous_sibling('span', class_='seats-info-label')
+        if label != None:
+            key = label.get_text().strip().rstrip(':').lower()
+        else:
+            # Testudo always renders the waitlist before the holdfile, so
+            # document order identifies them if the labels ever go away.
+            key = 'waitlist' if index == 0 else 'holdfile'
+        counts[key] = int(span.get_text())
+
+    # An absent waitlist means the section has no waitlist rather than an empty
+    # one, but every consumer of this data models that as zero people waiting.
+    return counts.get('waitlist', 0), counts.get('holdfile')
+
 def parse_section(div: BeautifulSoup, course: str):
     sec_code = div.find('input', {'name': 'sectionId'})['value']
     instructors = list(
@@ -75,9 +102,7 @@ def parse_section(div: BeautifulSoup, course: str):
     meetings = list(map(parse_meeting, meetings_divs))
     open_seats = int(div.find('span', class_='open-seats-count').get_text())
     total_seats = int(div.find('span', class_='total-seats-count').get_text())
-    try_waitlist_holdfile = div.find_all('span', class_='waitlist-count')
-    waitlist = int(try_waitlist_holdfile[0].get_text())
-    holdfile = None if len(try_waitlist_holdfile) == 1 else try_waitlist_holdfile[1].get_text()
+    waitlist, holdfile = parse_waitlist_and_holdfile(div)
     
     return {
         "course_code": course,

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,0 +1,123 @@
+'''
+Section parsing against the three shapes Testudo gives the seats block.
+
+The nightly scrape died on the third of them - a section with no waitlist at
+all - because the two counts were read out of `waitlist-count` by position and
+that markup contains no `waitlist-count` spans. One such section in a chunk
+raised `IndexError` out of the thread pool and took the entire run with it,
+which is why these are pinned as fixtures rather than trusted to stay stable.
+'''
+
+import os
+import sys
+
+from bs4 import BeautifulSoup
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sections import parse_section, parse_waitlist_and_holdfile
+
+
+def section(seats_info: str, sec_code: str = '0101') -> BeautifulSoup:
+    html = f'''
+    <div class="section">
+      <input type="hidden" name="sectionId" value="{sec_code}"/>
+      <span class="section-instructor">Ada Lovelace</span>
+      <span class="seats-info">{seats_info}</span>
+    </div>
+    '''
+    return BeautifulSoup(html, 'html.parser').find('div', class_='section')
+
+
+# A section with a waitlist and no holdfile: one `waitlist-count` span.
+WAITLIST_ONLY = '''
+  <span class="total-seats">(<span class="seats-info-label">Total:</span>
+    <span class="total-seats-count">35</span>,</span>
+  <span class="open-seats has-open-seats"><span class="seats-info-label">Open:</span>
+    <span class="open-seats-count">14</span>,</span>
+  <span class="waitlist">
+    <a href="https://registrar.umd.edu/registration/register-classes/waitlist-hold-file">
+      <span class="seats-info-label">Waitlist:</span>
+      <span class="waitlist-count">3</span>
+    </a>)
+  </span>
+'''
+
+# A full section that also runs a holdfile: two spans of the *same* class,
+# distinguished only by the label in front of each.
+WAITLIST_AND_HOLDFILE = '''
+  <span class="total-seats">(<span class="seats-info-label">Total:</span>
+    <span class="total-seats-count">90</span>,</span>
+  <span class="open-seats"><span class="seats-info-label">Open:</span>
+    <span class="open-seats-count">0</span>,</span>
+  <span class="waitlist has-waitlist">
+    <a href="https://registrar.umd.edu/registration/register-classes/waitlist-hold-file">
+      <span class="seats-info-label">Waitlist:</span>
+      <span class="waitlist-count">7</span>
+      <span class="seats-info-label">Holdfile:</span>
+      <span class="waitlist-count">2</span>
+    </a>)
+  </span>
+'''
+
+# The shape that broke the scrape: the `waitlist` wrapper is emitted with the
+# help link inside it but carries no counts whatsoever.
+NO_WAITLIST = '''
+  <span class="total-seats">(<span class="seats-info-label">Total:</span>
+    <span class="total-seats-count">12</span>,</span>
+  <span class="open-seats has-open-seats"><span class="seats-info-label">Open:</span>
+    <span class="open-seats-count">10</span>,</span>
+  <span class="waitlist">
+    <a href="https://registrar.umd.edu/registration/register-classes/waitlist-hold-file"></a>)
+  </span>
+'''
+
+
+@pytest.mark.parametrize('seats_info,expected', [
+    (WAITLIST_ONLY, (3, None)),
+    (WAITLIST_AND_HOLDFILE, (7, 2)),
+    (NO_WAITLIST, (0, None)),
+])
+def test_waitlist_and_holdfile(seats_info, expected):
+    assert parse_waitlist_and_holdfile(section(seats_info)) == expected
+
+
+def test_section_without_waitlist_still_parses():
+    '''
+    The regression itself: this raised `IndexError` and aborted the term.
+    '''
+    parsed = parse_section(section(NO_WAITLIST), 'BMGT848A')
+
+    assert parsed['course_code'] == 'BMGT848A'
+    assert parsed['sec_code'] == '0101'
+    assert parsed['open_seats'] == 10
+    assert parsed['total_seats'] == 12
+    assert parsed['waitlist'] == 0
+    assert parsed['holdfile'] is None
+
+
+def test_holdfile_is_a_number():
+    '''
+    `holdfile` is typed `number | null` by the site, so it must not come back
+    as the raw span text.
+    '''
+    parsed = parse_section(section(WAITLIST_AND_HOLDFILE), 'CMSC131')
+
+    assert parsed['waitlist'] == 7
+    assert parsed['holdfile'] == 2
+
+
+def test_labels_are_not_trusted_to_order_the_counts():
+    '''
+    Counts are keyed off their labels, so a holdfile listed first still lands
+    in the right field.
+    '''
+    reordered = WAITLIST_AND_HOLDFILE.replace(
+        '<span class="seats-info-label">Waitlist:</span>\n      <span class="waitlist-count">7</span>\n      '
+        '<span class="seats-info-label">Holdfile:</span>\n      <span class="waitlist-count">2</span>',
+        '<span class="seats-info-label">Holdfile:</span>\n      <span class="waitlist-count">2</span>\n      '
+        '<span class="seats-info-label">Waitlist:</span>\n      <span class="waitlist-count">7</span>'
+    )
+    assert reordered != WAITLIST_AND_HOLDFILE, 'fixture rewrite did not apply'
+    assert parse_waitlist_and_holdfile(section(reordered)) == (7, 2)


### PR DESCRIPTION
The bug
Testudo renders the waitlist and holdfile counts as two spans of the same class, waitlist-count, inside one wrapper, distinguishable only by the seats-info-label in front of each. sections.py read them positionally, which breaks at both ends of that markup.

What is failing:

185 sections (9%) have no waitlist. Testudo still emits the <span class="waitlist"> wrapper, but it holds only the help link — zero waitlist-count spans. [0] on an empty list raised IndexError, and since chunks parse in a ThreadPoolExecutor, that one section's exception surfaced out of executor.map and killed the whole term. That's the CI failure.
110 sections (5%) have a holdfile and no waitlist, so the single span present is the holdfile. Position read it as the waitlist. This one never crashed — it's been silently uploading holdfile counts into the waitlist field, so the site has been showing things like "Waitlist: 21" for sections with no waitlist at all. I found it only because keying off labels made the two disagree.


The fix
sections.py now keys each count off its preceding label, defaults waitlist to 0 when Testudo reports none, and falls back to document order if the labels ever disappear. Holdfile also returns an int instead of raw span text, matching the number | null that section.ts:15 already expects.

Verified by re-parsing all 2,083 live sections: no errors, types correct throughout.